### PR TITLE
copyright -> copyright law

### DIFF
--- a/content/words/public-domain.html
+++ b/content/words/public-domain.html
@@ -15,7 +15,7 @@ alignment: lawful
 
 {% block usage -%}
 
-Correctly to identify [works](/work) that are not restricted by [copyright](/copyright)
+Correctly to identify [works](/work) that are not restricted by [copyright](/copyright) law.
 
 Incorrectly in the context of any [information](/information) that is publicly available
 


### PR DESCRIPTION
emphasized "law" to clarify that this is a legal detail, also more consistent with new proposed discussion of copyright as emphasizing the legal facts about it.
