### PR TITLE
removed "information wants to be free"

### DIFF
--- a/content/words/information.html
+++ b/content/words/information.html
@@ -5,8 +5,6 @@ alignment: lawful
 
 {% block examples -%}
 
-"Information wants to be [free](/free)"
-
 "Copyright limits free flow of information"
 
 {%- endblock %}


### PR DESCRIPTION
It is a bad way to talk. We need to talk about freedom of people. Consider Corey Doctorow's emphasis that information does _not_ want to be free, don't personify information.

Whereas I strongly want my other pull requests merged, I'm less strong about this one. It's good it was in quotes at least. But I think removing this is an improvement.
